### PR TITLE
Add NPC dogs and add NPC to club room

### DIFF
--- a/PixelHunter1995/Content/Content.mgcb
+++ b/PixelHunter1995/Content/Content.mgcb
@@ -68,6 +68,18 @@
 /processorParam:TextureFormat=Color
 /build:Images/full_club_room.png
 
+#begin Images/full_club_room_chemistry_table.png
+/importer:TextureImporter
+/processor:TextureProcessor
+/processorParam:ColorKeyColor=255,0,255,255
+/processorParam:ColorKeyEnabled=True
+/processorParam:GenerateMipmaps=False
+/processorParam:PremultiplyAlpha=True
+/processorParam:ResizeToPowerOfTwo=False
+/processorParam:MakeSquare=False
+/processorParam:TextureFormat=Color
+/build:Images/full_club_room_chemistry_table.png
+
 #begin Images/hallway_club_room.png
 /importer:TextureImporter
 /processor:TextureProcessor
@@ -175,4 +187,16 @@
 /processorParam:MakeSquare=False
 /processorParam:TextureFormat=Color
 /build:Tileset/dogs.png
+
+#begin Tileset/npc_dogs.png
+/importer:TextureImporter
+/processor:TextureProcessor
+/processorParam:ColorKeyColor=255,0,255,255
+/processorParam:ColorKeyEnabled=True
+/processorParam:GenerateMipmaps=False
+/processorParam:PremultiplyAlpha=True
+/processorParam:ResizeToPowerOfTwo=False
+/processorParam:MakeSquare=False
+/processorParam:TextureFormat=Color
+/build:Tileset/npc_dogs.png
 

--- a/PixelHunter1995/Content/Images/full_club_room.png
+++ b/PixelHunter1995/Content/Images/full_club_room.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:922b737d16b9b88df8d5f21739932e1bd65a13a2d5b217ef70566e245d811449
-size 4750
+oid sha256:6ae1180646861f68819bfffb96616ebc28bcd2f272ee123310919cc97ebf75fe
+size 4492

--- a/PixelHunter1995/Content/Images/full_club_room_chemistry_table.png
+++ b/PixelHunter1995/Content/Images/full_club_room_chemistry_table.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:995af322a35e50bca13c8ec30a2424ed273644210fac341bed72f3e63cf72f75
+size 1183

--- a/PixelHunter1995/Content/Scenes/full_club_room.tmx
+++ b/PixelHunter1995/Content/Scenes/full_club_room.tmx
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.0" orientation="orthogonal" renderorder="right-down" width="712" height="160" tilewidth="1" tileheight="1" infinite="0" nextlayerid="8" nextobjectid="7">
+<map version="1.4" tiledversion="1.4.1" orientation="orthogonal" renderorder="right-down" width="712" height="160" tilewidth="1" tileheight="1" infinite="0" nextlayerid="9" nextobjectid="8">
  <tileset firstgid="1" source="../Tileset/dogs.tsx"/>
+ <tileset firstgid="65" source="../Tileset/npc_dogs.tsx"/>
  <imagelayer id="2" name="background">
   <image source="../Images/full_club_room.png" width="712" height="160"/>
+ </imagelayer>
+ <objectgroup id="4" name="dogs">
+  <object id="2" gid="1" x="479.091" y="98.1818" width="32" height="32"/>
+  <object id="3" gid="2" x="379.636" y="89.6364" width="32" height="32"/>
+  <object id="4" gid="3" x="46.5455" y="125.455" width="32" height="32"/>
+  <object id="7" gid="65" x="120" y="139" width="32" height="48"/>
+ </objectgroup>
+ <imagelayer id="8" name="foreground">
+  <image source="../Images/full_club_room_chemistry_table.png" width="712" height="160"/>
  </imagelayer>
  <objectgroup id="5" name="walking">
   <object id="5" x="623.667" y="116.667">
    <polygon points="0,0 25.6667,0.666667 66.6667,42 -460.333,40.6667 -451.667,11 -518.333,10.3333 -523.333,41 -622.333,42.3333 -622,32.3333 -571.333,-19 -256,-19.3333 -256,-15 -206.667,-13.6667 -206.667,9.33333 -165.667,13.3333 -92.3333,15.3333 -85,11.3333 -58.6667,6.66667 -60,-18.3333 -4,-18.6667 -2.66667,-1.66667"/>
   </object>
- </objectgroup>
- <objectgroup id="4" name="dogs">
-  <object id="2" gid="1" x="479.091" y="98.1818" width="32" height="32"/>
-  <object id="3" gid="2" x="379.636" y="89.6364" width="32" height="32"/>
-  <object id="4" gid="3" x="46.5455" y="125.455" width="32" height="32"/>
  </objectgroup>
  <objectgroup color="#006464" id="7" name="portals">
   <object id="6" x="652.182" y="72.5455">

--- a/PixelHunter1995/Content/Tileset/npc_dogs.png
+++ b/PixelHunter1995/Content/Tileset/npc_dogs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:717628a3c588b391c95e86ec0f7484529b4370b81b336738101c843fdd1ff30e
+size 2091

--- a/PixelHunter1995/Content/Tileset/npc_dogs.tsx
+++ b/PixelHunter1995/Content/Tileset/npc_dogs.tsx
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tileset version="1.4" tiledversion="1.4.1" name="npc_dogs" tilewidth="32" tileheight="48" tilecount="64" columns="8">
+ <image source="../Tileset/npc_dogs.png" width="256" height="384"/>
+</tileset>

--- a/PixelHunter1995/PixelHunter1995.csproj
+++ b/PixelHunter1995/PixelHunter1995.csproj
@@ -130,6 +130,7 @@
   <ItemGroup>
     <Content Include="Content\Images\club_room.png" />
     <Content Include="Content\Images\full_club_room.png" />
+    <Content Include="Content\Images\full_club_room_chemistry_table.png" />
     <Content Include="Content\Images\hallway_club_room.png" />
     <Content Include="Content\Images\hallway_principal.png" />
     <Content Include="Content\Images\hallway_soda.png" />
@@ -140,6 +141,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Content\Animations\felixia.png" />
+    <Content Include="Content\Tileset\npc_dogs.png" />
+    <Content Include="Content\Tileset\npc_dogs.tsx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Icon.ico" />
   </ItemGroup>
   <ItemGroup>

--- a/PixelHunter1995/SceneLib/SceneParser.cs
+++ b/PixelHunter1995/SceneLib/SceneParser.cs
@@ -19,7 +19,7 @@ namespace PixelHunter1995
             XmlDocument doc = new XmlDocument();
             doc.Load(sceneXmlPath);
             XmlNodeList nodes = doc.DocumentElement.ChildNodes;
-            Tileset tileset = null; // TODO: Possible to have many tilesets per scene?
+            Tileset tileset = null; // TODO: Make it possible to have many tilesets per scene
             List<IDrawable> drawables = new List<IDrawable>();
             List<IUpdateable> updateables = new List<IUpdateable>();
             List<ILoadContent> loadables = new List<ILoadContent>();
@@ -41,6 +41,7 @@ namespace PixelHunter1995
 
             foreach (XmlNode node in nodes)
             {
+                // TODO: Support "foreground" image layer as well.
                 if (node.Name == "imagelayer" && node.Attributes["name"]?.InnerText == "background")
                 {
                     Debug.Assert(node.ChildNodes.Count == 1);

--- a/extra/full_club_room.xcf
+++ b/extra/full_club_room.xcf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a051716842754c070e9c61a0b511b4b433c500a987ef9609feced1934d37f6c7
-size 107382
+oid sha256:252488f99df0fb323f9d177e891ebc6d7dd750b86002edc383c327e57c497a9c
+size 109010

--- a/extra/full_club_room_chemistry_table.xcf
+++ b/extra/full_club_room_chemistry_table.xcf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cc6388ffd9ae0e6e7561ff50aa37da151f8ac0b59b020644cefa90b70ce5135
+size 6937

--- a/extra/npc_dogs.pyxel
+++ b/extra/npc_dogs.pyxel
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b0146c12645fa572bce39ded4f77f86a18546020cd8b4a006e7dfc56c26e4b1
+size 2730

--- a/extra/spritesheet.pyxel
+++ b/extra/spritesheet.pyxel
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:46f45d3e3cd9a3de4961b6f9093c4ecf51b8c9165054324356b76c3219db171e
-size 9611
+oid sha256:ecc3eced6bbf592d2156ab6d1063599af11d738e74e38450e13def5b96add696
+size 9609


### PR DESCRIPTION
The NPC dogs are put in a separate tileset.

Also put the chemistry table in another image layer.

NOTE: Neither having multiple tilesets nor parsing image layers other
than the one named "background" has been implemented. This means
that the game crashes when trying to parse the scene. Thus #74 must
first be implemented before this is merged.