### PR TITLE
Call basicEffect.Dispose() when drawing polygon

### DIFF
--- a/PixelHunter1995/WalkingAreaLib/Polygon.cs
+++ b/PixelHunter1995/WalkingAreaLib/Polygon.cs
@@ -242,6 +242,7 @@ namespace PixelHunter1995.WalkingAreaLib
                     indexOffset,
                     drawIndices.Length - 1);
             }
+            basicEffect.Dispose();
         }
 
         public bool HasCommonEdgeWith(Polygon other)


### PR DESCRIPTION
We had a memory leak that occurred when running the game for around 20
minutes. This seems to have fixed that problem.