### PR TITLE
Fixed #88 (polygons drawn at bottom) and removed unused imports

### DIFF
--- a/PixelHunter1995/InventoryLib/Inventory.cs
+++ b/PixelHunter1995/InventoryLib/Inventory.cs
@@ -1,12 +1,10 @@
 ﻿
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
-using PixelHunter1995.Inputs;
 using PixelHunter1995.TilesetLib;
 
 namespace PixelHunter1995.InventoryLib

--- a/PixelHunter1995/Main.cs
+++ b/PixelHunter1995/Main.cs
@@ -5,7 +5,6 @@ using PixelHunter1995.GameStates;
 using PixelHunter1995.Utilities;
 using PixelHunter1995.Inputs;
 using System.IO;
-using Microsoft.Xna.Framework.Media;
 
 namespace PixelHunter1995
 {

--- a/PixelHunter1995/SceneLib/PolygonDog.cs
+++ b/PixelHunter1995/SceneLib/PolygonDog.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using PixelHunter1995.Utilities;
@@ -32,7 +28,7 @@ namespace PixelHunter1995.SceneLib
 
         public void Draw(GraphicsDeviceManager graphics, SpriteBatch spriteBatch, double scaling)
         {
-            Polygon.Draw(graphics);
+            Polygon.Draw(graphics, spriteBatch, scaling);
         }
 
         public int ZIndex()

--- a/PixelHunter1995/SceneLib/Scene.cs
+++ b/PixelHunter1995/SceneLib/Scene.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using PixelHunter1995.Inputs;
 using PixelHunter1995.SceneLib;
-using PixelHunter1995.Utilities;
 using System.Collections.Generic;
 
 namespace PixelHunter1995

--- a/PixelHunter1995/SceneLib/SceneParser.cs
+++ b/PixelHunter1995/SceneLib/SceneParser.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using System;
-using PixelHunter1995.Inputs;
 
 namespace PixelHunter1995
 {

--- a/PixelHunter1995/WalkingAreaLib/PolygonPartition.cs
+++ b/PixelHunter1995/WalkingAreaLib/PolygonPartition.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using System.Collections.Generic;
+using Microsoft.Xna.Framework.Graphics;
 
 namespace PixelHunter1995.WalkingAreaLib
 {
@@ -65,9 +66,9 @@ namespace PixelHunter1995.WalkingAreaLib
             return string.Join<Polygon>("; ", Polygons);
         }
 
-        public void Draw(GraphicsDeviceManager graphics)
+        public void Draw(GraphicsDeviceManager graphics, SpriteBatch spriteBatch, double scaling)
         {
-            Polygons.ForEach(p => p.Draw(graphics));
+            Polygons.ForEach(p => p.Draw(graphics, spriteBatch, scaling));
         }
     }
 }

--- a/PixelHunter1995/WalkingAreaLib/WalkingArea.cs
+++ b/PixelHunter1995/WalkingAreaLib/WalkingArea.cs
@@ -26,7 +26,7 @@ namespace PixelHunter1995.WalkingAreaLib
 
         public void Draw(GraphicsDeviceManager graphics, SpriteBatch spriteBatch, double scaling)
         {
-            partition.Draw(graphics);
+            partition.Draw(graphics, spriteBatch, scaling);
         }
 
         public int ZIndex()


### PR DESCRIPTION
Made polygons get drawn to a new rendertaget, which then can get drawn
to the regular spritebatch in the real rendertarget.
Had to forward spritebatch all the way down to Polygon.cs
Split Polygon.Draw into 2 extra helper-functions.