### PR TITLE
Path finding in walking area

### DIFF
--- a/PixelHunter1995/Utilities/Polygon.cs
+++ b/PixelHunter1995/Utilities/Polygon.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.Xna.Framework.Graphics;
 using PixelHunter1995.Utilities;
+using System;
 
 namespace PixelHunter1995.WalkingAreaLib
 {
@@ -183,7 +184,7 @@ namespace PixelHunter1995.WalkingAreaLib
 
         /// <summary>
         /// Checks if point is contained in the polygon.
-        /// Taken from https://stackoverflow.com/a/2922778
+        /// Taken from https://wrf.ecse.rpi.edu/Research/Short_Notes/pnpoly.html
         /// </summary>
         /// <param name="point"></param>
         /// <returns></returns>
@@ -197,6 +198,14 @@ namespace PixelHunter1995.WalkingAreaLib
                         (point.X < (vertices[j].X - vertices[i].X) * (point.Y - vertices[i].Y) /
                         (vertices[j].Y - vertices[i].Y) + vertices[i].X))
                     contains = !contains;
+            }
+            // As can be seen when following the documentation link edge cases are not certain to be included,
+            // but we need them to be (since we go there when someone click outside)
+            // TODO: Solve it for when we are on the edges and not only at the vertices.
+            if (!contains && vertices.Contains(point))
+            {
+                Console.WriteLine("At vertex but counted as outside...");
+                return true;
             }
             return contains;
         }

--- a/PixelHunter1995/Utilities/Polygon.cs
+++ b/PixelHunter1995/Utilities/Polygon.cs
@@ -200,11 +200,10 @@ namespace PixelHunter1995.WalkingAreaLib
                     contains = !contains;
             }
             // As can be seen when following the documentation link edge cases are not certain to be included,
-            // but we need them to be (since we go there when someone click outside)
+            // but we need them to be (since we go there when someone clicks outside)
             // TODO: Solve it for when we are on the edges and not only at the vertices.
             if (!contains && vertices.Contains(point))
             {
-                Console.WriteLine("At vertex but counted as outside...");
                 return true;
             }
             return contains;

--- a/PixelHunter1995/WalkingAreaLib/PolygonPartition.cs
+++ b/PixelHunter1995/WalkingAreaLib/PolygonPartition.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework.Graphics;
 using System.Linq;
@@ -9,11 +10,11 @@ namespace PixelHunter1995.WalkingAreaLib
     {
         public List<Polygon> Polygons { get; }
         public List<List<int>> Adjacents { get; }
+        public float[,] DistanceMatrix { get; }
 
         public PolygonPartition(List<Polygon> polygons)
         {
             Polygons = polygons;
-
             Adjacents = new List<List<int>>();
             for (int i = 0; i < polygons.Count; i++)
             {
@@ -29,6 +30,14 @@ namespace PixelHunter1995.WalkingAreaLib
                     {
                         Adjacents[i].Add(j);
                     }
+                }
+            }
+            DistanceMatrix = new float[Adjacents.Count, Adjacents.Count];
+            for (var i = 0; i < Adjacents.Count; i++)
+            {
+                foreach (var j in Adjacents[i])
+                {
+                    DistanceMatrix[i, j] = (Polygons[i].Center - Polygons[j].Center).LengthSquared();
                 }
             }
         }
@@ -75,6 +84,18 @@ namespace PixelHunter1995.WalkingAreaLib
         public bool Contains(Vector2 position)
         {
             return Polygons.Any(polygon => polygon.Contains(position));
+        }
+
+        public int ContainingPolygonIndex(Vector2 position)
+        {
+            for (int i = 0; i < Polygons.Count; i++)
+            {
+                if (Polygons[i].Contains(position))
+                {
+                    return i;
+                }
+            }
+            throw new ArgumentException("Position " + position + " outside of PolygonPartition.");
         }
     }
 }

--- a/PixelHunter1995/WalkingAreaLib/WalkingArea.cs
+++ b/PixelHunter1995/WalkingAreaLib/WalkingArea.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using PixelHunter1995.Utilities;
+using System;
 using System.Collections.Generic;
 
 namespace PixelHunter1995.WalkingAreaLib
@@ -51,8 +53,82 @@ namespace PixelHunter1995.WalkingAreaLib
                 }
                 clickPosition = closestVertex;
             }
-            return clickPosition;
-            // TODO: Lot of smart things here, coming in next review on path finding...
+            int currentIndex = partition.ContainingPolygonIndex(currentPosition);
+            int clickIndex = partition.ContainingPolygonIndex(clickPosition);
+            //Console.WriteLine("Player in polygon: " + currentIndex);
+            //Console.WriteLine("Clicked in polygon: " + clickIndex);
+            // Case1: In correct polygon
+            if (clickIndex == currentIndex)
+            {
+                return clickPosition;
+            }
+            // Case2: In adjacent polygon
+            if (partition.Adjacents[currentIndex].Contains(clickIndex))
+            {
+                return partition.Polygons[clickIndex].Center;
+            }
+            // Case3: Non adjecent Polygon, find adjacent polygon in correct direction.
+            int[] path = RunDijkstra(partition.Polygons.Count, partition.DistanceMatrix, currentIndex);
+            int temp = clickIndex;
+            Stack<int> stack = new Stack<int>();
+            while (temp != currentIndex)
+            {
+                stack.Push(temp);
+                temp = path[temp];
+            }
+            return partition.Polygons[stack.Pop()].Center;
+        }
+
+        // Taken from: https://simpledevcode.wordpress.com/2015/12/22/graphs-and-dijkstras-algorithm-c/
+        private int[] RunDijkstra(int graphSize, float[,] distanceMatrix, int sourceIndex)
+        {
+            float[] distance = new float[graphSize];
+            int[] previous = new int[graphSize];
+            for (int i = 0; i < graphSize; i++)
+            {
+                distance[i] = int.MaxValue;
+                previous[i] = 0;
+            }
+            PriorityQueue<int> pq = new PriorityQueue<int>();
+            //enqueue the source
+            distance[sourceIndex] = 0;
+            pq.Enqueue(sourceIndex, 0);
+            //insert all remaining vertices into the pq
+            for (int i = 0; i < graphSize; i++)
+            {
+                for (int j = 0; j < graphSize; j++)
+                {
+                    if (distanceMatrix[i, j] > 0)
+                    {
+                        pq.Enqueue(i, (int)distanceMatrix[i, j]);
+                    }
+                }
+            }
+            while (!pq.Empty())
+            {
+                int u = pq.Dequeue_min();
+                // scan each row fully
+                for (int v = 0; v < graphSize; v++)
+                {
+                    // if there is an adjacent node
+                    if (distanceMatrix[u, v] > 0)
+                    {
+                        float alt = distance[u] + distanceMatrix[u, v];
+                        if (alt < distance[v])
+                        {
+                            distance[v] = alt;
+                            previous[v] = u;
+                            pq.Enqueue(u, (int)distance[v]);
+                        }
+                    }
+                }
+            }
+            // Print distance to all Polygons for debugging
+            //for (int i = 0; i < graphSize; i++)
+            //{
+            //    Console.WriteLine("Distance from {0} to {1}: {2}", sourceIndex, i, distance[i]);
+            //}
+            return previous;
         }
 
         public int ZIndex()

--- a/PixelHunter1995/WalkingAreaLib/WalkingArea.cs
+++ b/PixelHunter1995/WalkingAreaLib/WalkingArea.cs
@@ -55,8 +55,6 @@ namespace PixelHunter1995.WalkingAreaLib
             }
             int currentIndex = partition.ContainingPolygonIndex(currentPosition);
             int clickIndex = partition.ContainingPolygonIndex(clickPosition);
-            //Console.WriteLine("Player in polygon: " + currentIndex);
-            //Console.WriteLine("Clicked in polygon: " + clickIndex);
             // Case1: In correct polygon
             if (clickIndex == currentIndex)
             {


### PR DESCRIPTION
Four cases:

1.Outside walking area:
Go to closest edge vertex.
Future improvement: Go to closest edge.

2. In current polygon:
Just go to click positin

3. In adjacent polygon
Go towards center of adjacent polygon (case 2 after crossed border)
Future improvement: Go to closest point of border.

4. In a non-adjacent polygon
Use Dijkstras algorithm to find shortest path. Get next polygon in
path and do as in 3.